### PR TITLE
encode/decode emojis

### DIFF
--- a/Classes/DBGHTMLEntityDecodeMap.m
+++ b/Classes/DBGHTMLEntityDecodeMap.m
@@ -288,11 +288,12 @@
         unsigned tempInt = 0;
         NSScanner *scanner = [NSScanner scannerWithString:[rawKey substringFromIndex:2]];
         if ([scanner scanHexInt:&tempInt]) {
-            if (tempInt > USHRT_MAX) {
+            if (tempInt < 0x10000) {
+                return [NSString stringWithFormat:@"%C", (unichar)tempInt];
+            } else if (tempInt <= 0x10FFFF) {
+                // code points in unicode supplementary planes
                 tempInt = NSSwapHostIntToLittle(tempInt);
                 return [[NSString alloc] initWithBytes:&tempInt length:sizeof(tempInt) encoding:NSUTF32LittleEndianStringEncoding];
-            } else {
-                return [NSString stringWithFormat:@"%C", (unichar)tempInt];
             }
         }
     } else if ([rawKey hasPrefix:@"#"]) {
@@ -300,11 +301,12 @@
         int tempInt = 0;
         NSScanner *scanner = [NSScanner scannerWithString:[rawKey substringFromIndex:1]];
         if ([scanner scanInt:&tempInt]) {
-            if (tempInt > USHRT_MAX) {
+            if (tempInt < 0x10000) {
+                return [NSString stringWithFormat:@"%C", (unichar)tempInt];
+            } else if (tempInt <= 0x10FFFF) {
+                // code points in unicode supplementary planes
                 tempInt = NSSwapHostIntToLittle(tempInt);
                 return [[NSString alloc] initWithBytes:&tempInt length:sizeof(tempInt) encoding:NSUTF32LittleEndianStringEncoding];
-            } else {
-                return [NSString stringWithFormat:@"%C", (unichar)tempInt];
             }
         }
     } else if (self.rawMap[rawKey]) {

--- a/Classes/DBGHTMLEntityDecodeMap.m
+++ b/Classes/DBGHTMLEntityDecodeMap.m
@@ -288,14 +288,24 @@
         unsigned tempInt = 0;
         NSScanner *scanner = [NSScanner scannerWithString:[rawKey substringFromIndex:2]];
         if ([scanner scanHexInt:&tempInt]) {
-            return [NSString stringWithFormat:@"%C", (unichar)tempInt];
+            if (tempInt > USHRT_MAX) {
+                tempInt = NSSwapHostIntToLittle(tempInt);
+                return [[NSString alloc] initWithBytes:&tempInt length:sizeof(tempInt) encoding:NSUTF32LittleEndianStringEncoding];
+            } else {
+                return [NSString stringWithFormat:@"%C", (unichar)tempInt];
+            }
         }
     } else if ([rawKey hasPrefix:@"#"]) {
         // it's decimal
         int tempInt = 0;
         NSScanner *scanner = [NSScanner scannerWithString:[rawKey substringFromIndex:1]];
         if ([scanner scanInt:&tempInt]) {
-            return [NSString stringWithFormat:@"%C", (unichar)tempInt];
+            if (tempInt > USHRT_MAX) {
+                tempInt = NSSwapHostIntToLittle(tempInt);
+                return [[NSString alloc] initWithBytes:&tempInt length:sizeof(tempInt) encoding:NSUTF32LittleEndianStringEncoding];
+            } else {
+                return [NSString stringWithFormat:@"%C", (unichar)tempInt];
+            }
         }
     } else if (self.rawMap[rawKey]) {
         // it exists as a named mapping

--- a/Classes/DBGHTMLEntityEncodeMap.h
+++ b/Classes/DBGHTMLEntityEncodeMap.h
@@ -12,18 +12,18 @@
  * Return the code point as a character entity reference.
  * If there is not a named mapping, return nil.
  */
-- (NSString *)encodeAsNamed:(unichar)inputChar;
+- (NSString *)encodeAsNamed:(UTF32Char)inputChar;
 
 /**
  * Returns the code point as a numeric character reference
  * encoded in hexidecimal form. e.g. - &#xhhhh;
  */
-- (NSString *)encodeAsHex:(unichar)inputChar;
+- (NSString *)encodeAsHex:(UTF32Char)inputChar;
 
 /**
  * Returns the code point as a numeric character reference
  * encoded in decimal form. e.g. - &#nnnn;
  */
-- (NSString *)encodeAsDecimal:(unichar)inputChar;
+- (NSString *)encodeAsDecimal:(UTF32Char)inputChar;
 
 @end

--- a/Classes/DBGHTMLEntityEncodeMap.m
+++ b/Classes/DBGHTMLEntityEncodeMap.m
@@ -45,12 +45,12 @@
 
 - (NSString *)encodeAsHex:(UTF32Char)inputChar {
     // check to make sure we SHOULD encode this hex value?
-    return [NSString stringWithFormat:@"&#x%x;", inputChar];
+    return [NSString stringWithFormat:@"&#x%lx;", (unsigned long)inputChar];
 }
 
 - (NSString *)encodeAsDecimal:(UTF32Char)inputChar {
     // check to make sure we SHOULD encode this decimal value?
-    return [NSString stringWithFormat:@"&#%d;", inputChar];
+    return [NSString stringWithFormat:@"&#%lu;", (unsigned long)inputChar];
 }
 
 @end

--- a/Classes/DBGHTMLEntityEncodeMap.m
+++ b/Classes/DBGHTMLEntityEncodeMap.m
@@ -35,20 +35,20 @@
     return _sharedMap;
 }
 
-- (NSString *)encodeAsNamed:(unichar)inputChar {
-    NSNumber *charNumber = [NSNumber numberWithUnsignedShort:inputChar];
+- (NSString *)encodeAsNamed:(UTF32Char)inputChar {
+    NSNumber *charNumber = [NSNumber numberWithUnsignedInt:inputChar];
     if (self.namedMap[charNumber]) {
         return [NSString stringWithFormat:@"&%@;", self.namedMap[charNumber]];
     }
     return nil;
 }
 
-- (NSString *)encodeAsHex:(unichar)inputChar {
+- (NSString *)encodeAsHex:(UTF32Char)inputChar {
     // check to make sure we SHOULD encode this hex value?
     return [NSString stringWithFormat:@"&#x%x;", inputChar];
 }
 
-- (NSString *)encodeAsDecimal:(unichar)inputChar {
+- (NSString *)encodeAsDecimal:(UTF32Char)inputChar {
     // check to make sure we SHOULD encode this decimal value?
     return [NSString stringWithFormat:@"&#%d;", inputChar];
 }

--- a/Classes/DBGHTMLEntityEncoder.m
+++ b/Classes/DBGHTMLEntityEncoder.m
@@ -62,22 +62,23 @@
     // for each range, try to decode as basic, then name, then decimal/hex
     for (NSValue *value in ranges) {
         NSRange range = [value rangeValue];
-        unichar theChar = [mutableString characterAtIndex:range.location];
+        UTF32Char theChar;
+        [mutableString getBytes:&theChar maxLength:sizeof(theChar) usedLength:NULL encoding:NSUTF32LittleEndianStringEncoding options:0 range:range remainingRange:NULL];
         NSString *replacement = nil;
         
         if (formats & DBGHTMLEntityEncoderNamedFormat) {
-            replacement = [encodeMap encodeAsNamed:theChar];
+            replacement = [encodeMap encodeAsNamed:NSSwapLittleIntToHost(theChar)];
             if (replacement) {
                 [mutableString replaceCharactersInRange:range withString:replacement];
                 continue;
             }
         }
         if (formats & DBGHTMLEntityEncoderDecimalFormat) {
-            [mutableString replaceCharactersInRange:range withString:[encodeMap encodeAsDecimal:theChar]];
+            [mutableString replaceCharactersInRange:range withString:[encodeMap encodeAsDecimal:NSSwapLittleIntToHost(theChar)]];
             continue;
         }
         if (formats & DBGHTMLEntityEncoderHexFormat) {
-            [mutableString replaceCharactersInRange:range withString:[encodeMap encodeAsHex:theChar]];
+            [mutableString replaceCharactersInRange:range withString:[encodeMap encodeAsHex:NSSwapLittleIntToHost(theChar)]];
             continue;
         }
     }

--- a/DBGHTMLEntities.podspec
+++ b/DBGHTMLEntities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "DBGHTMLEntities"
-  s.version          = "1.0.0"
+  s.version          = "1.1.0"
   s.summary          = "Easily Decode/Encode HTML entity strings (e.g. &amp;)"
   s.description      = <<-DESC
                        Easily Decode/Encode HTML entity strings (e.g. &amp;). Tested, and with a sexy LICENSE.

--- a/Example/DBGHTMLEntitiesExample/DBGDecodeExampleViewController.m
+++ b/Example/DBGHTMLEntitiesExample/DBGDecodeExampleViewController.m
@@ -70,7 +70,7 @@
 #pragma mark - String generators
 
 - (NSString *)basicString {
-    return @"Today &amp; tomorrow only, we&apos;ve got extra pies to give out. Not to be confused with &#960; #betterthandonuts, cc/ @dbgrandi";
+    return @"Today &amp; tomorrow only, we&apos;ve got extra pies to give out. Not to be confused with &#960; #betterthandonuts, cc/ @dbgrandi &#128077;";
 }
 
 - (NSMutableAttributedString *)tweetString {

--- a/Example/DBGHTMLEntitiesExample/DBGEncodeExampleViewController.m
+++ b/Example/DBGHTMLEntitiesExample/DBGEncodeExampleViewController.m
@@ -90,7 +90,7 @@
 #pragma mark - String generators
 
 - (NSString *)basicString {
-    return @"Today & tomorrow only, we've got extra pies to give out. Not to be confused with π #betterthandonuts, cc/ @dbgrandi ☺";
+    return @"Today & tomorrow only, we've got extra pies to give out. Not to be confused with π #betterthandonuts, cc/ @dbgrandi 👍 ☺";
 }
 
 - (NSMutableAttributedString *)tweetString {

--- a/Tests/DecodeMapSpec.m
+++ b/Tests/DecodeMapSpec.m
@@ -40,6 +40,7 @@ describe(@"DecodeMapSpec", ^{
         expect(decodeMap[@"&#8220;"]).to.equal(@"“");
         expect(decodeMap[@"&#8230;"]).to.equal(@"…");
         expect(decodeMap[@"&#32;"]).to.equal(@" ");
+        expect(decodeMap[@"&#128077;"]).to.equal(@"👍");
     });
 
     it(@"should decode hexadecimal entities", ^{
@@ -54,6 +55,7 @@ describe(@"DecodeMapSpec", ^{
         expect(decodeMap[@"1"]).to.beNil();
         expect(decodeMap[@"&;"]).to.beNil();
         expect(decodeMap[@""]).to.beNil();
+        expect(decodeMap[@"&#12345678;"]).to.beNil();
     });
 
 });

--- a/Tests/EncoderMapSpec.m
+++ b/Tests/EncoderMapSpec.m
@@ -54,11 +54,13 @@ describe(@"EncoderMapSpec", ^{
     it(@"should encode decimal entities", ^{
         expect([encodeMap encodeAsDecimal:L'“']).to.equal(@"&#8220;");
         expect([encodeMap encodeAsDecimal:L'…']).to.equal(@"&#8230;");
+        expect([encodeMap encodeAsDecimal:L'👍']).to.equal(@"&#128077;");
     });
     
     it(@"should encode hexadecimal entities", ^{
         expect([encodeMap encodeAsHex:L'−']).to.equal(@"&#x2212;");
         expect([encodeMap encodeAsHex:L'—']).to.equal(@"&#x2014;");
+        expect([encodeMap encodeAsHex:L'👍']).to.equal(@"&#x1f44d;");
     });
 
 });


### PR DESCRIPTION
Hi,

I need to decode HTML-encoded emojis like `&#128077;` (👍) but found that DBGHTMLEntityDecodeMap has issue dealing with characters higher than 65535.

This patch is derived from the "2. Byte buffers" solution in https://stackoverflow.com/questions/6458708/converting-an-nsstring-to-and-from-utf32 