### PR TITLE
Check empty or nil string before encode

### DIFF
--- a/Classes/DBGHTMLEntityDecoder.m
+++ b/Classes/DBGHTMLEntityDecoder.m
@@ -30,6 +30,7 @@ static NSString *DBGEntityRegexString = @"&(?:([a-z][a-z0-9]{1,7})|#([0-9]{1,7})
 }
 
 - (NSString *)decodeString:(NSString *)string {
+    if (string.length == 0) { return @""; };
     NSMutableString *mutableString = [string mutableCopy];
     [self decodeStringInPlace:mutableString];
 


### PR DESCRIPTION
When YF gets HRItemNews and parse it into YFArticle model, string being nil passes along. However, if we want to encode any string properties, this string can not be nil or empty.

I added a check at YFArticle, but it would be nice if `- (NSString *)decodeString:(NSString *)string {` handles it beforehand.